### PR TITLE
min macro conflict bewteen X library and STL - fixed

### DIFF
--- a/guicast/bcsignals.C
+++ b/guicast/bcsignals.C
@@ -13,12 +13,14 @@
 #include <unistd.h>
 #include <ucontext.h>
 #include <execinfo.h>
-#include <X11/Xlib.h>
-#include <X11/Xlibint.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <math.h>
 #include <values.h>
+
+#include <X11/Xlib.h>
+#include <X11/Xlibint.h>
+
 
 #define EPSILON (2e-6)
 


### PR DESCRIPTION
The build error was found on Archlinux. Fixed.